### PR TITLE
fix-of-a-memory-leak

### DIFF
--- a/src/fnft_nsev.c
+++ b/src/fnft_nsev.c
@@ -450,6 +450,8 @@ INT fnft_nsev(
         free(contspec_sub);
         free(bound_states_sub);
         free(normconsts_or_residues_sub);
+        if (normconsts_or_residues_reserve != normconsts_or_residues)
+            free(normconsts_or_residues_reserve);
         return ret_code;
 }
 


### PR DESCRIPTION
If memory was allocated at
https://github.com/FastNFT/FNFT/blob/db8d0687f00ac0af7f406f094c9b24474c3605ee/src/fnft_nsev.c#L256
it was never freed.